### PR TITLE
feat: update cloudflare provider to 4.36.0

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,28 +2,28 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "4.35.0"
-  constraints = "4.35.0"
+  version     = "4.36.0"
+  constraints = "4.36.0"
   hashes = [
-    "h1:3u/KZcsYfLLP0nkho9Xl8CJ+nsXx9XcAgoMHSH/coUQ=",
-    "h1:A4Ajss0uoxCLXhnv+v1VDaHgv5etNAqY+On/dM4GHVU=",
-    "h1:fNjBstW/04Pfh/HsiGwrsq+1KfuK7IP92ifcdMY7jzE=",
-    "h1:fW8LeirSQPeh38RZfrt3eKtpzMLsj9teewqVWa+t18o=",
-    "zh:0977dff393d42da9a2d4ccb7b51b4c4af8ef03ee8642effd9106cd8ef3e33d28",
-    "zh:14da7557ad9f18d30518eab416cf8e6b8a571d896dc56d0ee322828841c44bad",
-    "zh:34c395c38ac7b2e510b0c6d5e6b3344bb3449467304471abddef1ae7485b2f48",
-    "zh:62f6ed85df4159b7058364823597f977bd2d79aab7145294f5858cf6a6c49c9f",
-    "zh:73ac5f16f3781215f381b1c33714e0d5599015c878d35760f0de336a7716dbdb",
-    "zh:7be3f69f2514d1cbd7c220c05f11b555c655df7df6658635021b095394ee2c17",
-    "zh:7ee3f9fc6027c4e2729ca874a425b7be569a639375206e0d527774613933497a",
+    "h1:7cnczyKGj3+gvaJ0r5JIVWLXPbQfkHYejac76MJx+I8=",
+    "h1:Xx6WUD/zB8fM9SjkFx06Fgx2K7aGJIVvsJS2pwqALEM=",
+    "h1:eKCvfashdCqfDcFGXE2gq+XxAURD5SzuaQ9Brs3zLos=",
+    "h1:zjzavjIdLDGRYsWd3v0HJz6ul12Cewj9RW/cqAQ4DxI=",
+    "zh:02665712b3893307596b3caab99cf1f2502d5caca18e22d4b37bb535e628e102",
+    "zh:1514b0d3ef62934484ac471113ee68cddec0c21e56b4f710922741fe9b6e6fdf",
+    "zh:1fab4dfcecbcea13267b42e5ff05ba0692aa2dcb247b8e633fea0daf49feb156",
+    "zh:24d8367295fe1f1b2be37802aecb96edf32f743364663ffe781d1bb92438395d",
+    "zh:34e84e7940c99dcf65663cfd25afac22bf5c8a5ff2cd21900c67180d3a072be9",
+    "zh:3d71d63204a329acf1d1de8638f2c725243cb94cf444d2d7acde54b3d1ac1696",
+    "zh:57831ba88e779a762bcfa224ba9eac8bc22ef9cd70cd541d848b351e0ba6a75c",
+    "zh:6407560f2e548afcb4852c91efc664627a9ee565c31a9c81fc9ea1806fca0567",
+    "zh:738ddbc664d75f4859aa09444a27809bc398795a8ea8f5be8531040690287712",
+    "zh:841ca2b2d78b6f8d33ec3435bc090c5e04a3a7d85c80df11227a7ea00d36f6b1",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:90b3f50df1d495afdb2c4e281d4bfe45280e0ddc81d05322fa47576949b85f75",
-    "zh:b35e05557b597b2d30fa8ff2ec014deac2c735d477addb9709405986f332ff61",
-    "zh:b98b75faae1c03ae08e26558042ff241157220aade45776309c34f1f82840281",
-    "zh:c281cfb5b74aee2b7fb77ec682554d43668af0a4717ba7f11d5c06adeacc553a",
-    "zh:d0364ab9e34be0a41fa5627ff515dcfc03092177bcf4d30f02640b993f299f48",
-    "zh:e804034167abf4f65dbb51982064355326cc98febf4f6d2330e65712edb846e3",
-    "zh:fddc437f70153980a2e6e7b25b87a44a5354f88dae85c81a6950a577209cc024",
+    "zh:8b3d3d63354032ab9b2403c50728e9aa4e83c7367eaad2d18794221addeafc0f",
+    "zh:9e293443fe3127e488f540229983c1b9688268185f87567bb3d18e794697acd2",
+    "zh:b3a22439156e46461213db183e2e89569cd2e8d7cbcfc4b9f90469090e105807",
+    "zh:f430feb5d51891e84028459e57039045dea4f1f5fcf671161d8ac2d8f28763f3",
   ]
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "4.35.0"
+      source  = "registry.terraform.io/cloudflare/cloudflare"
+      version = "4.36.0"
     }
     vsphere = {
-      source  = "hashicorp/vsphere"
+      source  = "registry.terraform.io/hashicorp/vsphere"
       version = "2.8.1"
     }
   }


### PR DESCRIPTION
- Update cloudflare provider version from 4.35.0 to 4.36.0 in .terraform.lock.hcl and versions.tf
- Refresh provider hashes in .terraform.lock.hcl for the new version
- Adjust source attribute for cloudflare and vsphere providers in versions.tf to include registry URL