### PR TITLE
feat(virtual-machine): add support for optional DNS server list and time zone configuration

### DIFF
--- a/modules/virtual-machine/main.tf
+++ b/modules/virtual-machine/main.tf
@@ -54,6 +54,7 @@ resource "vsphere_virtual_machine" "vm" {
         for_each = local.is_windows_template ? [1] : []
         content {
           computer_name = var.name
+          time_zone     = var.time_zone != null ? var.time_zone : null
         }
       }
       dynamic "linux_options" {
@@ -61,11 +62,14 @@ resource "vsphere_virtual_machine" "vm" {
         content {
           host_name = var.name
           domain    = ""
+          time_zone = var.time_zone != null ? var.time_zone : null
         }
       }
+      dns_server_list = var.dns_server_list != null ? var.dns_server_list : null
       network_interface {
-        ipv4_address = split("/", var.ipv4_with_cidr)[0]
-        ipv4_netmask = split("/", var.ipv4_with_cidr)[1]
+        ipv4_address    = split("/", var.ipv4_with_cidr)[0]
+        ipv4_netmask    = split("/", var.ipv4_with_cidr)[1]
+        dns_server_list = var.dns_server_list != null ? var.dns_server_list : null
       }
       ipv4_gateway = cidrhost(var.ipv4_with_cidr, 1)
     }

--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -13,6 +13,11 @@ variable "datastore" {
   type        = string
 }
 
+variable "dns_server_list" {
+  description = "The DNS servers to use"
+  type        = optional(list(string))
+}
+
 variable "cluster" {
   description = "The cluster to use"
   type        = string
@@ -41,6 +46,11 @@ variable "folder" {
 variable "template" {
   description = "The template to clone"
   type        = string
+}
+
+variable "time_zone" {
+  description = "The time zone to use"
+  type        = optional(string)
 }
 
 variable "linked_clone" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,16 +16,18 @@ variable "vsphere_server" {
 variable "virtual_machines" {
   description = "The list of virtual machines to create"
   type = map(object({
-    cluster        = string
-    datacenter     = string
-    datastore      = string
-    folder         = string
-    memory         = number
-    name           = string
-    network        = string
-    num_cpus       = number
-    template       = string
-    ipv4_with_cidr = string
+    cluster         = string
+    datacenter      = string
+    datastore       = string
+    dns_server_list = optional(list(string))
+    folder          = string
+    ipv4_with_cidr  = string
+    memory          = number
+    name            = string
+    network         = string
+    num_cpus        = number
+    template        = string
+    time_zone       = optional(string)
   }))
   default = {}
 }


### PR DESCRIPTION
- Introduced `dns_server_list` and `time_zone` as optional variables in `variables.tf` for virtual machines.
- Updated `main.tf` to configure `dns_server_list` and `time_zone` for both Windows and Linux options.
- Enhanced network interface configuration to include DNS server list if provided.