### PR TITLE
fix(variables): update dns_server_list type to list(string) and make it nullable

### DIFF
--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -15,7 +15,8 @@ variable "datastore" {
 
 variable "dns_server_list" {
   description = "The DNS servers to use"
-  type        = optional(list(string))
+  type        = list(string)
+  nullable    = true
 }
 
 variable "cluster" {


### PR DESCRIPTION
The dns_server_list variable has been adjusted because you are not able to use the optional keyword outside of objects.