### PR TITLE
fix(variables): update time_zone variable to be a nullable string

### DIFF
--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -51,7 +51,8 @@ variable "template" {
 
 variable "time_zone" {
   description = "The time zone to use"
-  type        = optional(string)
+  type        = string
+  nullable    = true
 }
 
 variable "linked_clone" {


### PR DESCRIPTION
The time_zone variable needs to also be updated because the optional keyword only works in objects