### PR TITLE
fix(virtual-machine): remove null checks for time_zone and dns_server_list

### DIFF
--- a/modules/virtual-machine/main.tf
+++ b/modules/virtual-machine/main.tf
@@ -54,7 +54,7 @@ resource "vsphere_virtual_machine" "vm" {
         for_each = local.is_windows_template ? [1] : []
         content {
           computer_name = var.name
-          time_zone     = var.time_zone != null ? var.time_zone : null
+          time_zone     = var.time_zone
         }
       }
       dynamic "linux_options" {
@@ -62,14 +62,14 @@ resource "vsphere_virtual_machine" "vm" {
         content {
           host_name = var.name
           domain    = ""
-          time_zone = var.time_zone != null ? var.time_zone : null
+          time_zone = var.time_zone
         }
       }
-      dns_server_list = var.dns_server_list != null ? var.dns_server_list : null
+      dns_server_list = var.dns_server_list
       network_interface {
         ipv4_address    = split("/", var.ipv4_with_cidr)[0]
         ipv4_netmask    = split("/", var.ipv4_with_cidr)[1]
-        dns_server_list = var.dns_server_list != null ? var.dns_server_list : null
+        dns_server_list = var.dns_server_list
       }
       ipv4_gateway = cidrhost(var.ipv4_with_cidr, 1)
     }

--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -16,7 +16,7 @@ variable "datastore" {
 variable "dns_server_list" {
   description = "The DNS servers to use"
   type        = list(string)
-  nullable    = true
+  default     = []
 }
 
 variable "cluster" {
@@ -52,7 +52,7 @@ variable "template" {
 variable "time_zone" {
   description = "The time zone to use"
   type        = string
-  nullable    = true
+  default     = "UTC"
 }
 
 variable "linked_clone" {


### PR DESCRIPTION
- Updated `main.tf` to remove null checks for `time_zone` and `dns_server_list` variables.
- Set default value for `dns_server_list` to an empty list in `variables.tf`.
- Set default value for `time_zone` to "UTC" in `variables.tf`.