### PR TITLE
feat: add linked_clone option to virtual machine module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "virtual-machine" {
   dns_server_list = each.value.dns_server_list
   folder          = each.value.folder
   ipv4_with_cidr  = each.value.ipv4_with_cidr
+  linked_clone    = each.value.linked_clone
   memory          = each.value.memory
   name            = each.value.name
   network         = each.value.network

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "virtual_machines" {
     dns_server_list = optional(list(string))
     folder          = string
     ipv4_with_cidr  = string
+    linked_clone    = optional(bool)
     memory          = number
     name            = string
     network         = string


### PR DESCRIPTION
- Introduced a new optional parameter `linked_clone` in the `virtual-machine` module.
- Updated `variables.tf` to include `linked_clone` as an optional boolean.
- This allows configuration of linked clones for virtual machines.