### PR TITLE
feat(virtual-machine): add configurable disk size option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "virtual-machine" {
   cluster         = each.value.cluster
   datacenter      = each.value.datacenter
   datastore       = each.value.datastore
+  disk_size       = each.value.disk_size
   dns_server_list = each.value.dns_server_list
   folder          = each.value.folder
   ipv4_with_cidr  = each.value.ipv4_with_cidr

--- a/modules/virtual-machine/main.tf
+++ b/modules/virtual-machine/main.tf
@@ -51,7 +51,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
   disk {
     label            = "disk0"
-    size             = data.vsphere_virtual_machine.template.disks.0.size
+    size             = var.disk_size != null ? var.disk_size : data.vsphere_virtual_machine.template.disks.0.size
     thin_provisioned = true
   }
   clone {

--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -66,3 +66,9 @@ variable "ipv4_with_cidr" {
   type        = string
   default     = null
 }
+
+variable "disk_size" {
+  description = "The size of the disk in GB. If not provided, uses template disk size."
+  type        = number
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable "virtual_machines" {
     cluster         = string
     datacenter      = string
     datastore       = string
+    disk_size       = optional(number)
     dns_server_list = optional(list(string))
     folder          = string
     ipv4_with_cidr  = string


### PR DESCRIPTION
Allow users to specify a custom disk size for virtual machines. If not provided, the default template disk size is used. This enhances flexibility in VM configuration.