### PR TITLE
refactor(vm): switch from cluster to resource pool

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "virtual-machine" {
     vsphere = vsphere
   }
 
-  cluster         = each.value.cluster
+  resource_pool   = each.value.resource_pool
   datacenter      = each.value.datacenter
   datastore       = each.value.datastore
   disk_size       = each.value.disk_size

--- a/modules/virtual-machine/main.tf
+++ b/modules/virtual-machine/main.tf
@@ -7,9 +7,9 @@ data "vsphere_datastore" "datastore" {
   name          = var.datastore
 }
 
-data "vsphere_compute_cluster" "cluster" {
+data "vsphere_resource_pool" "resource_pool" {
   datacenter_id = data.vsphere_datacenter.datacenter.id
-  name          = var.cluster
+  name          = var.resource_pool
 }
 
 data "vsphere_network" "network" {
@@ -35,7 +35,7 @@ resource "vsphere_virtual_machine" "vm" {
   name                   = var.name
   datastore_id           = data.vsphere_datastore.datastore.id
   guest_id               = data.vsphere_virtual_machine.template.guest_id
-  resource_pool_id       = data.vsphere_compute_cluster.cluster.resource_pool_id
+  resource_pool_id       = data.vsphere_resource_pool.pool.id
   num_cpus               = var.num_cpus
   cpu_hot_add_enabled    = true
   cpu_hot_remove_enabled = true

--- a/modules/virtual-machine/variables.tf
+++ b/modules/virtual-machine/variables.tf
@@ -19,8 +19,8 @@ variable "dns_server_list" {
   default     = []
 }
 
-variable "cluster" {
-  description = "The cluster to use"
+variable "resource_pool" {
+  description = "The resource pool to use"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "vsphere_server" {
 variable "virtual_machines" {
   description = "The list of virtual machines to create"
   type = map(object({
-    cluster         = string
+    resource_pool   = string
     datacenter      = string
     datastore       = string
     disk_size       = optional(number)


### PR DESCRIPTION
BREAKING CHANGE: Updated configuration to use resource pools instead of clusters for virtual machine provisioning. This change requires updating the input variables and module configurations to align with the new resource pool structure.